### PR TITLE
Update error messages and tests, hide detail view when error shows

### DIFF
--- a/cypress/e2e/detailed_view_spec.cy.js
+++ b/cypress/e2e/detailed_view_spec.cy.js
@@ -20,7 +20,7 @@ describe('Detailed page experience', () => {
     cy.get('.detail-right-container')
     cy.contains('Mulan')
     cy.contains('When the Emperor of China issues a decree that one man per family must serve in the Imperial Chinese Army to defend the country from Huns, Hua Mulan, the eldest daughter of an honored warrior, steps in to take the place of her ailing father. She is spirited, determined and quick on her feet. Disguised as a man by the name of Hua Jun, she is tested every step of the way and must harness her innermost strength and embrace her true potential.')
-    cy.contains('Rating: 5.1/10')
+    cy.contains('Rating: 5/10')
     cy.get('.detail-icon-styling').should('exist')
     cy.contains('Budget: $200M')
     cy.contains('Revenue: $57M')
@@ -58,20 +58,20 @@ describe('Detailed page experience', () => {
   it('should display error message if server returns 500 error', () => {
     cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/400160', { statusCode: 500, fixture: './spongebob-data.json' })
       .visit('http://localhost:3000/400160')
-    cy.contains('Sorry! Something went wrong. Please try again later')
+    cy.contains('Sorry! Please try again later. Error:')
     cy.get('.error-image').should('exist')
   })
 
   it('should display error message if server returns 400 error', () => {
     cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/400160', { statusCode: 404, fixture: './spongebob-data.json' })
       .visit('http://localhost:3000/400160')
-      cy.contains('Sorry! Something went wrong. Please try again later')
+      cy.contains('Sorry! Please try again later. Error: Not Found')
       cy.get('.error-image').should('exist')
   })
 
   it('should display error message if URL does not exist', () => {
     cy.visit('http://localhost:3000/test')
-    cy.contains('Sorry! Something went wrong. Please try again later')
+    cy.contains('Sorry! Please try again later. Error: Internal Server Error')
     cy.get('.error-image').should('exist')
   })
 })

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -27,8 +27,8 @@ class App extends Component {
         this.setState({ movieData: data.movies })
         this.getRandomMovie()
       })
-      .catch(error => {
-        this.setState({ error: `Sorry! Something went wrong. Please try again later.` })
+      .catch(errorCode => {
+        this.setState({ error: `Sorry! Please try again later. ${errorCode}`})
       })
   }
 

--- a/src/Banner/Banner.js
+++ b/src/Banner/Banner.js
@@ -13,7 +13,7 @@ const Banner = ({ randomMovie }) => {
       <div className="banner-subcontainer" style={divStyle}>
         <div className="title-button-container">
           <h3 className="random-movie-title">{randomMovie.title}</h3>
-          <Link to={`/id/${randomMovie.id}`}>
+          <Link to={`/${randomMovie.id}`}>
             <button className="random-movie-button">View details</button>
           </Link>
           </div>

--- a/src/MovieDetailView/MovieDetailView.js
+++ b/src/MovieDetailView/MovieDetailView.js
@@ -21,8 +21,9 @@ class MovieDetailView extends Component {
       .then(data => {
         this.setState({ selectedMovie: data.movie })
       })
-      .catch(error => {
-        this.setState({ error: `Sorry! Something went wrong. Please try again later.` })
+      .catch(errorCode => {
+        console.log("LOOK HERE", errorCode)
+        this.setState({ error: `Sorry! Please try again later. ${errorCode}`})
       })
   }
 
@@ -57,11 +58,10 @@ class MovieDetailView extends Component {
         ? <li>Budget: ${(revenue / 1000).toFixed(0)}K</li>
         : <li>Revenue: not available</li>)
 
-    
+    if (!this.state.error) {
     return (
       <div>
         <NavDetailedView />
-        {this.state.error && <Error error={this.state.error} /> }
         <div className="detail-backdrop-container">
           <img src={backdrop_path} className='poster-styling' />
         </div>
@@ -89,7 +89,9 @@ class MovieDetailView extends Component {
         </div>
       </div>
     )
-
+    } else {
+      return (<div>{<NavDetailedView />}{<Error error={this.state.error} />}</div>)
+    }
   }
 }
 

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -2,12 +2,12 @@ const getFetch = (address) => {
   return fetch(`https://rancid-tomatillos.herokuapp.com/api/v2/${address}`)
     .then(response => {
       if (!response.ok) {
-        throw Error(response.text)
+        throw Error(response.statusText)
      } else {
         return response.json()
     }
   })
-//   .catch(error => console.log(error))
+  // .catch(error => console.log("TEST",error))
 }
 
 export default getFetch


### PR DESCRIPTION
Summary: 
This branch adds detail to the error messages and updates the Cypress tests accordingly. This also hides the detail view when the error screen appears.

How to test:
1. Download branch and `npm run cypress` for the detail view. See that all tests are passing with added detail to the error messages that are expected.
2. In the UI, test adding a movie id that doesn't exist to the end of the URL and see if the error screen appears without the detail view also appearing below it.