### PR TITLE
Fix fetch error for trailer and make detail view load at the page

### DIFF
--- a/src/MovieDetailView/MovieDetailView.js
+++ b/src/MovieDetailView/MovieDetailView.js
@@ -19,20 +19,21 @@ class MovieDetailView extends Component {
   }
 
   componentDidMount = () => {
+    window.scrollTo(0, 0)
+    getFetch(`movies/${this.state.id}/videos`)
+    .then(data => {
+      this.setState({ randomVideo: data.videos[0].key })
+      this.setState({videoMessage: "Watch trailer"})
+    })
+    .catch(errorCode => {
+      this.setState({videoMessage: "No trailer found"})
+    })
     getFetch(`movies/${this.state.id}`)
       .then(data => {
         this.setState({ selectedMovie: data.movie })
       })
       .catch(errorCode => {
         this.setState({ error: `Sorry! Please try again later. ${errorCode}` })
-      })
-    getFetch(`movies/${this.state.id}/videos`)
-      .then(data => {
-          this.setState({ randomVideo: data.videos[0].key })
-          this.setState({videoMessage: "Watch trailer"})
-      })
-      .catch(errorCode => {
-        this.setState({videoMessage: "No trailer found"})
       })
   }
 


### PR DESCRIPTION
- Makes detail view load at the top of the page so user does not have to scroll to the top 
- Fixes issue where trailers were loading with an error 